### PR TITLE
docs: add two new miscellaneous resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ If you find anything missing or want to update existing resources, you can creat
 
 ### 12. Miscellaneous Resources:
 
+- [Security and Audting Course by Cyfrin Updraft](https://updraft.cyfrin.io/courses/security)
+- [Web3 Security Course by Gateway](http://course.intogateway.com)
 - [Smart Contract Hacking Course by JohnnyTime](https://smartcontractshacking.com/)
 - [Web3Suggests](https://web3suggest.xyz/)
 - [Web3-Security-Library](https://github.com/immunefi-team/Web3-Security-Library)


### PR DESCRIPTION
**Purpose of this Pull Request**

I've added two new miscellaneous resources (to section 12). These resources include courses by Cyfrin Updraft and Gateway.

1. [Security and Auditing Course by Cyfrin Updraft](https://updraft.cyfrin.io/courses/security)
2. [Web3 Security Course by Gateway](http://course.intogateway.com/)

**Additional Context**

I believe these resources are valuable additions to this curated list because they provide comprehensive courses on blockchain security for auditors. 

I've ensured that the formatting and structure of these entries are consistent with the other items in this section. 

If any further changes or adjustments are needed, please let me know, and I'll be happy to make them.